### PR TITLE
feat/#15 AI 챗봇 API 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,4 +86,5 @@ jobs:
               -e S3_BUCKETNAME=${{ secrets.S3_BUCKETNAME }} \
               -e WEATHER_API_KEY=${{ secrets.WEATHER_API_KEY }} \
               -e KAKAO_API_KEY=${{ secrets.KAKAO_API_KEY }} \
+              -e AI_SERVER_URL=${{ secrets.AI_SERVER_URL }} \
               ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY }}:${{ github.sha }}

--- a/src/main/java/com/likelion/artipick/chat/api/ChatController.java
+++ b/src/main/java/com/likelion/artipick/chat/api/ChatController.java
@@ -1,0 +1,50 @@
+package com.likelion.artipick.chat.api;
+
+import com.likelion.artipick.chat.api.dto.request.AiRequest;
+import com.likelion.artipick.chat.api.dto.request.ChatRequest;
+import com.likelion.artipick.chat.api.dto.response.ChatHistoryResponse;
+import com.likelion.artipick.chat.application.ChatService;
+import com.likelion.artipick.global.code.dto.ApiResponse;
+import com.likelion.artipick.global.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "채팅 API", description = "AI 챗봇과의 대화")
+@RestController
+@RequestMapping("/api/chat")
+@RequiredArgsConstructor
+public class ChatController {
+
+    private final ChatService chatService;
+
+    @Operation(summary = "챗봇에게 메시지 전송", description = "사용자 메시지를 AI 챗봇에게 전송합니다.")
+    @PostMapping("/send")
+    public ResponseEntity<ApiResponse<Void>> sendMessage(
+            @Valid @RequestBody ChatRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        chatService.sendMessage(request, userDetails.getUserId()).block();
+        return ResponseEntity.ok(ApiResponse.onSuccess(null));
+    }
+
+    @Operation(summary = "챗봇 응답 받기", description = "AI 서버에서 분석된 챗봇 응답을 받습니다.")
+    @PostMapping("/receive")
+    public ResponseEntity<ApiResponse<Void>> receiveAiResponse(@Valid @RequestBody AiRequest request) {
+        chatService.receiveMessage(request).block();
+        return ResponseEntity.ok(ApiResponse.onSuccess(null));
+    }
+
+    @Operation(summary = "대화 기록 조회", description = "사용자의 전체 대화 기록을 조회합니다.")
+    @GetMapping("/history")
+    public ResponseEntity<ApiResponse<List<ChatHistoryResponse>>> getChatHistory(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        List<ChatHistoryResponse> history = chatService.getChatHistory(userDetails.getUserId()).block();
+        return ResponseEntity.ok(ApiResponse.onSuccess(history));
+    }
+}

--- a/src/main/java/com/likelion/artipick/chat/api/dto/request/AiRequest.java
+++ b/src/main/java/com/likelion/artipick/chat/api/dto/request/AiRequest.java
@@ -1,0 +1,16 @@
+package com.likelion.artipick.chat.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "AI 응답 요청")
+public record AiRequest(
+        @Schema(description = "사용자 ID", example = "123")
+        @NotNull(message = "사용자 ID는 필수입니다")
+        Long userId,
+
+        @Schema(description = "AI 응답 메시지", example = "예술의 전당 OO전시회를 추천합니다.")
+        @NotBlank(message = "응답 메시지는 필수입니다")
+        String response
+) {}

--- a/src/main/java/com/likelion/artipick/chat/api/dto/request/AiServerRequest.java
+++ b/src/main/java/com/likelion/artipick/chat/api/dto/request/AiServerRequest.java
@@ -1,0 +1,20 @@
+package com.likelion.artipick.chat.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "AI 서버 요청 (내부용)")
+public record AiServerRequest(
+        @Schema(description = "사용자 ID", example = "123")
+        Long userId,
+
+        @Schema(description = "사용자 메시지", example = "오늘 날씨 어때?")
+        String message,
+
+        @Schema(description = "타임스탬프", example = "2025-01-15T10:30:00")
+        String timestamp
+) {
+    public static AiServerRequest of(Long userId, String message) {
+        return new AiServerRequest(userId, message,
+                java.time.LocalDateTime.now().toString());
+    }
+}

--- a/src/main/java/com/likelion/artipick/chat/api/dto/request/ChatRequest.java
+++ b/src/main/java/com/likelion/artipick/chat/api/dto/request/ChatRequest.java
@@ -1,0 +1,13 @@
+package com.likelion.artipick.chat.api.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "채팅 메시지 요청")
+public record ChatRequest(
+        @Schema(description = "사용자 메시지", example = "오늘 갈만한 서울 전시회 추천해줘")
+        @NotBlank(message = "메시지는 필수입니다.")
+        @Size(max = 1000, message = "메시지는 1000자를 초과할 수 없습니다.")
+        String message
+) {}

--- a/src/main/java/com/likelion/artipick/chat/api/dto/response/ChatHistoryResponse.java
+++ b/src/main/java/com/likelion/artipick/chat/api/dto/response/ChatHistoryResponse.java
@@ -1,0 +1,22 @@
+package com.likelion.artipick.chat.api.dto.response;
+
+import com.likelion.artipick.chat.domain.MessageType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDateTime;
+
+@Schema(description = "채팅 기록 응답")
+public record ChatHistoryResponse(
+        @Schema(description = "메시지 내용", example = "전시회 추천")
+        String content,
+
+        @Schema(description = "메시지 타입", example = "USER")
+        MessageType messageType,
+
+        @Schema(description = "전송 시간", example = "2025-01-15T10:30:00")
+        LocalDateTime timestamp
+) {
+    public static ChatHistoryResponse of(String content, MessageType messageType, LocalDateTime timestamp) {
+        return new ChatHistoryResponse(content, messageType, timestamp);
+    }
+}

--- a/src/main/java/com/likelion/artipick/chat/application/ChatService.java
+++ b/src/main/java/com/likelion/artipick/chat/application/ChatService.java
@@ -1,0 +1,95 @@
+package com.likelion.artipick.chat.application;
+
+import com.likelion.artipick.chat.api.dto.request.AiRequest;
+import com.likelion.artipick.chat.api.dto.request.AiServerRequest;
+import com.likelion.artipick.chat.api.dto.request.ChatRequest;
+import com.likelion.artipick.chat.api.dto.response.ChatHistoryResponse;
+import com.likelion.artipick.chat.domain.ChatMessage;
+import com.likelion.artipick.chat.domain.MessageType;
+import com.likelion.artipick.chat.domain.repository.ChatMessageRepository;
+import com.likelion.artipick.global.code.status.ErrorStatus;
+import com.likelion.artipick.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ChatService {
+
+    private final ChatMessageRepository chatMessageRepository;
+    private final WebClient webClient;
+
+    @Value("${ai.server.url}")
+    private String aiServerUrl;
+
+    public Mono<Void> sendMessage(ChatRequest request, Long userId) {
+        return Mono.fromCallable(() -> {
+                    // 사용자 메시지 저장
+                    ChatMessage userMessage = ChatMessage.builder()
+                            .userId(userId)
+                            .content(request.message())
+                            .messageType(MessageType.USER)
+                            .build();
+                    return chatMessageRepository.save(userMessage);
+                })
+                .flatMap(savedMessage -> {
+                    // AI 서버로 전송할 DTO 생성
+                    AiServerRequest aiRequest = AiServerRequest.of(userId, request.message());
+
+                    // AI 서버로 비동기 전송
+                    return webClient.post()
+                            .uri(aiServerUrl + "/chat")
+                            .bodyValue(aiRequest)
+                            .retrieve()
+                            .bodyToMono(String.class)
+                            .doOnNext(response -> log.info("AI 서버 응답 성공: {}", response))
+                            .then(); // 응답 내용은 무시하고 완료 신호만 전달
+                })
+                .onErrorMap(e -> {
+                    log.error("AI 서버 통신 오류", e);
+                    return new GeneralException(ErrorStatus.AI_SERVER_ERROR);
+                });
+    }
+
+    public Mono<Void> receiveMessage(AiRequest request) {
+        return Mono.fromCallable(() -> {
+                    ChatMessage aiResponse = ChatMessage.builder()
+                            .userId(request.userId())
+                            .content(request.response())
+                            .messageType(MessageType.AI)
+                            .build();
+                    return chatMessageRepository.save(aiResponse);
+                })
+                .doOnNext(savedMessage -> log.info("AI 응답 저장 완료: {}", savedMessage.getId()))
+                .then()  // 저장 완료 후 Void 반환
+                .onErrorMap(e -> {
+                    log.error("채팅 메시지 저장 오류", e);
+                    return new GeneralException(ErrorStatus.CHAT_SAVE_ERROR);
+                });
+    }
+
+    public Mono<List<ChatHistoryResponse>> getChatHistory(Long userId) {
+        return Mono.fromCallable(() -> {
+                    List<ChatMessage> messages = chatMessageRepository.findByUserIdOrderByCreatedAtAsc(userId);
+
+                    return messages.stream()
+                            .map(message -> ChatHistoryResponse.of(
+                                    message.getContent(),
+                                    message.getMessageType(),
+                                    message.getCreatedAt()
+                            ))
+                            .toList();
+                })
+                .onErrorMap(e -> {
+                    log.error("채팅 기록 조회 오류", e);
+                    return new GeneralException(ErrorStatus.DATABASE_ERROR);
+                });
+    }
+}

--- a/src/main/java/com/likelion/artipick/chat/domain/ChatMessage.java
+++ b/src/main/java/com/likelion/artipick/chat/domain/ChatMessage.java
@@ -1,0 +1,36 @@
+package com.likelion.artipick.chat.domain;
+
+import com.likelion.artipick.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "chat_messages")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ChatMessage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, length = 1000)
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private MessageType messageType;
+
+    @Builder
+    public ChatMessage(Long userId, String content, MessageType messageType) {
+        this.userId = userId;
+        this.content = content;
+        this.messageType = messageType;
+    }
+}

--- a/src/main/java/com/likelion/artipick/chat/domain/MessageType.java
+++ b/src/main/java/com/likelion/artipick/chat/domain/MessageType.java
@@ -1,0 +1,5 @@
+package com.likelion.artipick.chat.domain;
+
+public enum MessageType {
+    USER, AI
+}

--- a/src/main/java/com/likelion/artipick/chat/domain/repository/ChatMessageRepository.java
+++ b/src/main/java/com/likelion/artipick/chat/domain/repository/ChatMessageRepository.java
@@ -1,0 +1,22 @@
+package com.likelion.artipick.chat.domain.repository;
+
+import com.likelion.artipick.chat.domain.ChatMessage;
+import com.likelion.artipick.chat.domain.MessageType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
+
+    // 특정 사용자의 최신 AI 응답 조회
+    @Query("SELECT c FROM ChatMessage c " +
+            "WHERE c.userId = :userId AND c.messageType =:messageType " +
+            "ORDER BY c.createdAt DESC LIMIT 1")
+    Optional<ChatMessage> findLatestMessageByUserIdAndType(@Param("userId") Long userId, @Param("messageType") MessageType messageType);
+
+    // 특정 사용자의 모든 채팅 기록 조회 (시간순)
+    List<ChatMessage> findByUserIdOrderByCreatedAtAsc(Long userId);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -64,3 +64,8 @@ weather:
 kakao:
   api:
     key: ${KAKAO_API_KEY}
+
+# AI 서버 설정
+ai:
+  server:
+    url: ${AI_SERVER_URL} # 수정 필요


### PR DESCRIPTION
# 구현 기능

- WebClient를 이용하여 비동기로 AI 챗봇과 연결
- 챗봇에게 메시지 전송 및 DB에 저장
- 챗봇한테 메시지를 받아와서 DB에 저장
- 대화 목록 조회