### PR TITLE
날씨 및 위치정보 변환 API 비인가 사용자 사용 가능하도록 수정

### DIFF
--- a/src/main/java/com/likelion/artipick/global/security/SecurityConfig.java
+++ b/src/main/java/com/likelion/artipick/global/security/SecurityConfig.java
@@ -39,7 +39,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**",
                                 "/swagger-resources/**", "/webjars/**",
-                                "/auth/login", "/auth/reissue"
+                                "/auth/login", "/auth/reissue", "/api/weather/**", "/api/location/**"
                         ).permitAll()
                         .requestMatchers("/api/**").authenticated()
                         .anyRequest().authenticated()


### PR DESCRIPTION
# 구현 기능

- "/api/weather/**", "/api/location/**" 추가