### PR TITLE
feat/#28: 문화 정보 공공 API 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,4 +87,5 @@ jobs:
               -e WEATHER_API_KEY=${{ secrets.WEATHER_API_KEY }} \
               -e KAKAO_API_KEY=${{ secrets.KAKAO_API_KEY }} \
               -e AI_SERVER_URL=${{ secrets.AI_SERVER_URL }} \
+              -e CULTURE_API_KEY=${{ secrets.CULTURE_API_KEY }} \
               ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY }}:${{ github.sha }}

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,8 @@ dependencies {
     // WebClient
     implementation 'org.springframework:spring-webflux'
     implementation 'io.projectreactor.netty:reactor-netty-http'
+    // XML
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/likelion/artipick/ArtipickApplication.java
+++ b/src/main/java/com/likelion/artipick/ArtipickApplication.java
@@ -3,7 +3,9 @@ package com.likelion.artipick;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
 public class ArtipickApplication {

--- a/src/main/java/com/likelion/artipick/culture/api/CultureController.java
+++ b/src/main/java/com/likelion/artipick/culture/api/CultureController.java
@@ -1,0 +1,44 @@
+package com.likelion.artipick.culture.api;
+
+import com.likelion.artipick.culture.api.dto.response.CultureListResponse;
+import com.likelion.artipick.culture.api.dto.response.CultureResponse;
+import com.likelion.artipick.culture.application.CultureService;
+import com.likelion.artipick.global.code.dto.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "문화행사", description = "문화행사 관련 API")
+@RestController
+@RequestMapping("/api/cultures")
+@RequiredArgsConstructor
+public class CultureController {
+
+    private final CultureService cultureService;
+
+    @Operation(summary = "문화행사 목록 조회", description = "문화행사 목록을 페이징하여 조회합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<CultureListResponse>>> getCulture(
+            @Parameter(description = "페이지 정보") @PageableDefault(size = 20)Pageable pageable) {
+
+        Page<CultureListResponse> cultures = cultureService.findAllCultures(pageable)
+                .map(CultureListResponse::from);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(cultures));
+    }
+
+    @Operation(summary = "문화행사 상세 조회", description = "특정 문화행사의 상세 정보를 조회합니다.")
+    @GetMapping("/{cultureId}")
+    public ResponseEntity<ApiResponse<CultureResponse>> getCulture(
+            @Parameter(description = "문화행사 ID", example = "1") @PathVariable Long cultureId) {
+
+        CultureResponse culture = CultureResponse.from(cultureService.findCultureById(cultureId));
+        return ResponseEntity.ok(ApiResponse.onSuccess(culture));
+    }
+}

--- a/src/main/java/com/likelion/artipick/culture/api/dto/response/CultureDetailApiResponse.java
+++ b/src/main/java/com/likelion/artipick/culture/api/dto/response/CultureDetailApiResponse.java
@@ -1,0 +1,128 @@
+package com.likelion.artipick.culture.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Schema(description = "문화행사 상세 API 응답")
+@XmlRootElement(name = "response")
+@XmlAccessorType(XmlAccessType.FIELD)
+@Getter
+@NoArgsConstructor
+public class CultureDetailApiResponse {
+
+    @Schema(description = "응답 헤더")
+    private Header header;
+
+    @Schema(description = "응답 본문")
+    private Body body;
+
+    @Schema(description = "응답 헤더 정보")
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @Getter
+    @NoArgsConstructor
+    public static class Header {
+        @Schema(description = "결과 코드")
+        private String resultCode;
+
+        @Schema(description = "결과 메시지")
+        private String resultMsg;
+    }
+
+    @Schema(description = "응답 본문 데이터")
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @Getter
+    @NoArgsConstructor
+    public static class Body {
+        @Schema(description = "문화행사 목록")
+        private Items items;
+
+        @Schema(description = "페이지당 행 수")
+        @XmlElement(name = "numOfrows")
+        private Integer numOfRows;
+
+        @Schema(description = "페이지 번호")
+        @XmlElement(name = "PageNo")
+        private Integer pageNo;
+
+        @Schema(description = "전체 건수")
+        private Integer totalCount;
+    }
+
+    @Schema(description = "문화행사 아이템 목록")
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @Getter
+    @NoArgsConstructor
+    public static class Items {
+        @Schema(description = "문화행사 배열")
+        @XmlElement(name = "item")
+        private List<CultureDetailItem> item;
+    }
+
+    @Schema(description = "문화행사 상세 정보")
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @Getter
+    @NoArgsConstructor
+    public static class CultureDetailItem {
+        @Schema(description = "문화행사 고유번호", example = "319005")
+        private String seq;
+
+        @Schema(description = "문화행사 제목", example = "패트릭 블랑: 수직정원")
+        private String title;
+
+        @Schema(description = "시작일 (yyyyMMdd)", example = "20180616")
+        private String startDate;
+
+        @Schema(description = "종료일 (yyyyMMdd)", example = "20281231")
+        private String endDate;
+
+        @Schema(description = "장소명", example = "부산현대미술관")
+        private String place;
+
+        @Schema(description = "분야명", example = "전시")
+        private String realmName;
+
+        @Schema(description = "지역", example = "부산")
+        private String area;
+
+        @Schema(description = "시군구", example = "사하구")
+        private String sigungu;
+
+        @Schema(description = "가격 정보")
+        private String price;
+
+        @Schema(description = "상세내용")
+        @XmlElement(name = "contents1")
+        private String contents;
+
+        @Schema(description = "URL")
+        private String url;
+
+        @Schema(description = "전화번호")
+        private String phone;
+
+        @Schema(description = "이미지 URL")
+        private String imgUrl;
+
+        @Schema(description = "경도", example = "128.9427422591895")
+        private String gpsX;
+
+        @Schema(description = "위도", example = "35.10921642590141")
+        private String gpsY;
+
+        @Schema(description = "장소 URL")
+        private String placeUrl;
+
+        @Schema(description = "장소 주소")
+        private String placeAddr;
+
+        @Schema(description = "장소 순번")
+        private String placeSeq;
+    }
+}

--- a/src/main/java/com/likelion/artipick/culture/api/dto/response/CultureListApiResponse.java
+++ b/src/main/java/com/likelion/artipick/culture/api/dto/response/CultureListApiResponse.java
@@ -1,0 +1,109 @@
+package com.likelion.artipick.culture.api.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Schema(description = "문화행사 리스트 API 응답")
+@XmlRootElement(name = "response")
+@XmlAccessorType(XmlAccessType.FIELD)
+@Getter
+@NoArgsConstructor
+public class CultureListApiResponse {
+
+    @Schema(description = "응답 헤더")
+    private Header header;
+
+    @Schema(description = "응답 본문")
+    private Body body;
+
+    @Schema(description = "응답 헤더 정보")
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @Getter
+    @NoArgsConstructor
+    public static class Header {
+        @Schema(description = "결과 코드")
+        private String resultCode;
+
+        @Schema(description = "결과 메시지")
+        private String resultMsg;
+    }
+
+    @Schema(description = "응답 본문 데이터")
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @Getter
+    @NoArgsConstructor
+    public static class Body {
+        @Schema(description = "문화행사 목록")
+        private Items items;
+
+        @Schema(description = "페이지당 행 수")
+        @XmlElement(name = "numOfrows")
+        private Integer numOfRows;
+
+        @Schema(description = "페이지 번호")
+        @XmlElement(name = "PageNo")
+        private Integer pageNo;
+
+        @Schema(description = "전체 건수")
+        private Integer totalCount;
+    }
+
+    @Schema(description = "문화행사 아이템 목록")
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @Getter
+    @NoArgsConstructor
+    public static class Items {
+        @Schema(description = "문화행사 배열")
+        @XmlElement(name = "item")
+        private List<CultureListItem> item;
+    }
+
+    @Schema(description = "문화행사 리스트 정보")
+    @XmlAccessorType(XmlAccessType.FIELD)
+    @Getter
+    @NoArgsConstructor
+    public static class CultureListItem {
+        @Schema(description = "서비스 분류", example = "공연/전시")
+        private String serviceName;
+
+        @Schema(description = "문화행사 고유번호", example = "319005")
+        private String seq;
+
+        @Schema(description = "문화행사 제목", example = "패트릭 블랑: 수직정원")
+        private String title;
+
+        @Schema(description = "시작일 (yyyyMMdd)", example = "20180616")
+        private String startDate;
+
+        @Schema(description = "종료일 (yyyyMMdd)", example = "20281231")
+        private String endDate;
+
+        @Schema(description = "장소명", example = "부산현대미술관")
+        private String place;
+
+        @Schema(description = "분야명", example = "전시")
+        private String realmName;
+
+        @Schema(description = "지역", example = "부산")
+        private String area;
+
+        @Schema(description = "시군구", example = "사하구")
+        private String sigungu;
+
+        @Schema(description = "썸네일 이미지")
+        private String thumbnail;
+
+        @Schema(description = "경도", example = "128.9427422591895")
+        private String gpsX;
+
+        @Schema(description = "위도", example = "35.10921642590141")
+        private String gpsY;
+    }
+}

--- a/src/main/java/com/likelion/artipick/culture/api/dto/response/CultureListResponse.java
+++ b/src/main/java/com/likelion/artipick/culture/api/dto/response/CultureListResponse.java
@@ -1,0 +1,55 @@
+package com.likelion.artipick.culture.api.dto.response;
+
+import com.likelion.artipick.culture.domain.Category;
+import com.likelion.artipick.culture.domain.Culture;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+
+@Schema(description = "문화행사 목록 조회 응답")
+public record CultureListResponse(
+        @Schema(description = "문화행사 ID", example = "1")
+        Long id,
+
+        @Schema(description = "문화행사 제목", example = "패트릭 블랑: 수직정원")
+        String title,
+
+        @Schema(description = "시작일", example = "2018-06-16")
+        LocalDate startDate,
+
+        @Schema(description = "종료일", example = "2028-12-31")
+        LocalDate endDate,
+
+        @Schema(description = "장소명", example = "부산현대미술관")
+        String place,
+
+        @Schema(description = "카테고리", example = "EXHIBITION")
+        Category category,
+
+        @Schema(description = "지역", example = "부산")
+        String area,
+
+        @Schema(description = "가격 정보", example = "무료")
+        String price,
+
+        @Schema(description = "이미지 URL", example = "http://www.culture.go.kr/upload/rdf/23/07/show_202307716201843746.jpg")
+        String imgUrl,
+
+        @Schema(description = "API 데이터 여부", example = "true")
+        Boolean isFromApi
+) {
+    public static CultureListResponse from(Culture culture) {
+        return new CultureListResponse(
+                culture.getId(),
+                culture.getTitle(),
+                culture.getStartDate(),
+                culture.getEndDate(),
+                culture.getPlace(),
+                culture.getCategory(),
+                culture.getArea(),
+                culture.getPrice(),
+                culture.getImgUrl(),
+                culture.getIsFromApi()
+        );
+    }
+}

--- a/src/main/java/com/likelion/artipick/culture/api/dto/response/CultureResponse.java
+++ b/src/main/java/com/likelion/artipick/culture/api/dto/response/CultureResponse.java
@@ -1,0 +1,79 @@
+package com.likelion.artipick.culture.api.dto.response;
+
+import com.likelion.artipick.culture.domain.Category;
+import com.likelion.artipick.culture.domain.Culture;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+
+@Schema(description = "문화행사 상세 조회 응답")
+public record CultureResponse(
+        @Schema(description = "문화행사 ID", example = "1")
+        Long id,
+
+        @Schema(description = "공공API 고유번호", example = "319005")
+        String seq,
+
+        @Schema(description = "문화행사 제목", example = "패트릭 블랑: 수직정원")
+        String title,
+
+        @Schema(description = "시작일", example = "2018-06-16")
+        LocalDate startDate,
+
+        @Schema(description = "종료일", example = "2028-12-31")
+        LocalDate endDate,
+
+        @Schema(description = "장소명", example = "부산현대미술관")
+        String place,
+
+        @Schema(description = "카테고리", example = "EXHIBITION")
+        Category category,
+
+        @Schema(description = "지역", example = "부산")
+        String area,
+
+        @Schema(description = "시군구", example = "사하구")
+        String sigungu,
+
+        @Schema(description = "가격 정보", example = "무료")
+        String price,
+
+        @Schema(description = "장소 주소", example = "부산광역시 사하구 낙동남로 1191 부산 현대미술관")
+        String placeAddr,
+
+        @Schema(description = "장소 URL", example = "https://www.busan.go.kr/moca/index")
+        String placeUrl,
+
+        @Schema(description = "전화번호", example = "부산현대미술관 051-220-7400~1")
+        String phone,
+
+        @Schema(description = "상세내용")
+        String contents,
+
+        @Schema(description = "이미지 URL", example = "http://www.culture.go.kr/upload/rdf/23/07/show_202307716201843746.jpg")
+        String imgUrl,
+
+        @Schema(description = "API 데이터 여부", example = "true")
+        Boolean isFromApi
+) {
+    public static CultureResponse from(Culture culture) {
+        return new CultureResponse(
+                culture.getId(),
+                culture.getSeq(),
+                culture.getTitle(),
+                culture.getStartDate(),
+                culture.getEndDate(),
+                culture.getPlace(),
+                culture.getCategory(),
+                culture.getArea(),
+                culture.getSigungu(),
+                culture.getPrice(),
+                culture.getPlaceAddr(),
+                culture.getPlaceUrl(),
+                culture.getPhone(),
+                culture.getContents(),
+                culture.getImgUrl(),
+                culture.getIsFromApi()
+        );
+    }
+}

--- a/src/main/java/com/likelion/artipick/culture/application/CultureScheduler.java
+++ b/src/main/java/com/likelion/artipick/culture/application/CultureScheduler.java
@@ -1,0 +1,18 @@
+package com.likelion.artipick.culture.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CultureScheduler {
+
+    private final CultureService cultureService;
+
+    @Scheduled(fixedRate = 14 * 24 * 60 * 60 * 1000L) // 2주마다
+    public void syncCultureData() {
+        cultureService.scheduledSync()
+                .subscribe();
+    }
+}

--- a/src/main/java/com/likelion/artipick/culture/application/CultureService.java
+++ b/src/main/java/com/likelion/artipick/culture/application/CultureService.java
@@ -1,0 +1,157 @@
+package com.likelion.artipick.culture.application;
+
+import com.likelion.artipick.culture.api.dto.response.CultureDetailApiResponse;
+import com.likelion.artipick.culture.client.CultureApiClient;
+import com.likelion.artipick.culture.domain.Category;
+import com.likelion.artipick.culture.domain.Culture;
+import com.likelion.artipick.culture.domain.repository.CultureRepository;
+import com.likelion.artipick.global.code.status.ErrorStatus;
+import com.likelion.artipick.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+import reactor.util.retry.Retry;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CultureService {
+
+    private final CultureRepository cultureRepository;
+    private final CultureApiClient cultureApiClient;
+
+    @Transactional
+    public Mono<Void> scheduledSync() {
+        return Flux.range(1, 3)
+                .concatMap(page -> syncCultureEventsByPageReactive(page, 35)) // concatMap (순서 보장)
+                .then()
+                .doOnSuccess(unused -> log.info("전체 동기화 완료"))
+                .doOnError(error -> log.error("전체 동기화 실패", error));
+    }
+
+
+    public Page<Culture> findAllCultures(Pageable pageable) {
+        return cultureRepository.findAll(pageable);
+    }
+
+    public Culture findCultureById(Long id) {
+        return cultureRepository.findById(id)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_FOUND));
+    }
+
+    private Mono<List<Culture>> syncCultureEventsByPageReactive(int page, int size) {
+        log.info("페이지 {} 동기화 시작 (요청 크기: {})", page, size);
+
+        return cultureApiClient.getCultureSeqList(page, size)
+                .onErrorResume(throwable -> {
+                    log.error("페이지 {} seq 목록 조회 실패", page, throwable);
+                    return Mono.just(List.of());
+                })
+                .flatMapMany(Flux::fromIterable)
+                .flatMap(seq ->
+                        Mono.fromCallable(() -> cultureRepository.existsBySeq(seq))
+                                .subscribeOn(Schedulers.boundedElastic())
+                                .map(exists -> exists ? null : seq)
+                                .onErrorResume(throwable -> {
+                                    log.debug("seq {} 존재 여부 확인 실패: {}", seq, throwable.getMessage());
+                                    return Mono.empty();
+                                })
+                , 3) // 동시 실행 개수 제한
+                .filter(Objects::nonNull)
+                .flatMap(seq -> saveDetailData(seq)
+                        .onErrorResume(throwable -> {
+                            log.warn("seq {} 저장 실패, 스킵: {}", seq, throwable.getMessage());
+                            return Mono.empty();
+                        })
+                , 2) // 동시 실행 개수 제한
+                .collectList()
+                .doOnNext(cultures ->
+                        log.info("페이지 {} 동기화 완료: {} 건 성공", page, cultures.size())
+                );
+    }
+
+    private Mono<Culture> saveDetailData(String seq) {
+        return cultureApiClient.getCultureEventBySeq(seq)
+                .timeout(Duration.ofSeconds(15))
+                .retryWhen(Retry.backoff(3, Duration.ofSeconds(1)))
+                .map(this::extractCultureItem)
+                .map(this::convertToEntity)
+                .flatMap(culture ->
+                        Mono.fromCallable(() -> {
+                                    try {
+                                        return cultureRepository.save(culture);
+                                    } catch (DataIntegrityViolationException e) {
+                                        log.debug("중복 seq 스킵: {}", seq);
+                                        return culture;
+                                    } catch (Exception e) {
+                                        log.error("seq {} 저장 중 예상치 못한 오류", seq, e);
+                                        throw new GeneralException(ErrorStatus.DATABASE_ERROR);
+                                    }
+                                })
+                                .subscribeOn(Schedulers.boundedElastic())
+                );
+    }
+
+    private CultureDetailApiResponse.CultureDetailItem extractCultureItem(CultureDetailApiResponse response) {
+        if (response == null || response.getBody() == null || response.getBody().getItems() == null ||
+                response.getBody().getItems().getItem() == null || response.getBody().getItems().getItem().isEmpty()) {
+            throw new GeneralException(ErrorStatus.CULTURE_API_EMPTY_RESPONSE);
+        }
+        return response.getBody().getItems().getItem().get(0);
+    }
+
+    private Culture convertToEntity(CultureDetailApiResponse.CultureDetailItem item) {
+        return Culture.builder()
+                .seq(item.getSeq())
+                .title(item.getTitle())
+                .startDate(parseDate(item.getStartDate()))
+                .endDate(parseDate(item.getEndDate()))
+                .place(item.getPlace())
+                .category(convertToCategory(item.getRealmName()))
+                .area(item.getArea())
+                .sigungu(item.getSigungu())
+                .price(item.getPrice())
+                .placeAddr(item.getPlaceAddr())
+                .gpsX(item.getGpsX())
+                .gpsY(item.getGpsY())
+                .placeUrl(item.getPlaceUrl())
+                .phone(item.getPhone())
+                .contents(item.getContents())
+                .imgUrl(item.getImgUrl())
+                .isFromApi(true)
+                .build();
+    }
+
+    private LocalDate parseDate(String dateString) {
+        if (dateString == null || dateString.trim().isEmpty()) {
+            return LocalDate.now();
+        }
+        try {
+            return LocalDate.parse(dateString, DateTimeFormatter.ofPattern("yyyyMMdd"));
+        } catch (Exception e) {
+            return LocalDate.now();
+        }
+    }
+
+    private Category convertToCategory(String realmName) {
+        return Arrays.stream(Category.values())
+                .filter(category -> category.getDisplayName().equals(realmName))
+                .findFirst()
+                .orElse(Category.ETC);
+    }
+}

--- a/src/main/java/com/likelion/artipick/culture/client/CultureApiClient.java
+++ b/src/main/java/com/likelion/artipick/culture/client/CultureApiClient.java
@@ -1,0 +1,78 @@
+package com.likelion.artipick.culture.client;
+
+import com.likelion.artipick.culture.api.dto.response.CultureDetailApiResponse;
+import com.likelion.artipick.culture.api.dto.response.CultureListApiResponse;
+import com.likelion.artipick.global.code.status.ErrorStatus;
+import com.likelion.artipick.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CultureApiClient {
+
+    private final WebClient webClient;
+
+    @Value("${culture.api.base-url}")
+    private String baseUrl;
+
+    @Value("${culture.api.auth-key}")
+    private String authKey;
+
+    public Mono<CultureListApiResponse> getCultureEvents(int pageNo, int numOfRows) {
+        String encodedKey = URLEncoder.encode(authKey, StandardCharsets.UTF_8);
+        String url = String.format("%s/period2?serviceKey=%s&PageNo=%d&numOfrows=%d", baseUrl, encodedKey, pageNo, numOfRows);
+
+        return webClient.get()
+                .uri(URI.create(url))
+                .accept(MediaType.APPLICATION_XML)
+                .retrieve()
+                .bodyToMono(CultureListApiResponse.class)
+                .onErrorMap(e -> {
+                    log.error("Culture API 호출 실패", e);
+                    return new GeneralException(ErrorStatus.CULTURE_API_ERROR);
+                });
+    }
+
+    public Mono<CultureDetailApiResponse> getCultureEventBySeq(String seq) {
+        String encodedKey = URLEncoder.encode(authKey, StandardCharsets.UTF_8);
+        String url = String.format("%s/detail2?serviceKey=%s&seq=%s", baseUrl, encodedKey, seq);
+
+        return webClient.get()
+                .uri(URI.create(url))
+                .accept(MediaType.APPLICATION_XML)
+                .retrieve()
+                .bodyToMono(CultureDetailApiResponse.class)
+                .onErrorMap(e -> {
+                    log.error("Culture detail API 호출 실패: seq={}", seq, e);
+                    return new GeneralException(ErrorStatus.CULTURE_API_ERROR);
+                });
+    }
+
+    public Mono<List<String>> getCultureSeqList(int pageNo, int numOfRows) {
+        return getCultureEvents(pageNo, numOfRows)
+                .map(this::extractSeqList);
+    }
+
+    private List<String> extractSeqList(CultureListApiResponse response) {
+        if (response.getBody() == null || response.getBody().getItems() == null || response.getBody().getItems().getItem() == null) {
+            return List.of();
+        }
+
+        return response.getBody().getItems().getItem()
+                .stream()
+                .map(CultureListApiResponse.CultureListItem::getSeq)
+                .toList();
+    }
+}

--- a/src/main/java/com/likelion/artipick/culture/domain/Category.java
+++ b/src/main/java/com/likelion/artipick/culture/domain/Category.java
@@ -1,0 +1,21 @@
+package com.likelion.artipick.culture.domain;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Category {
+    EXHIBITION("전시"),
+    THEATER("연극"),
+    EDUCATION("교육/체험"),
+    MUSICAL("뮤지컬/오페라"),
+    MUSIC("음악/콘서트"),
+    TRADITIONAL("국악"),
+    FESTIVAL("행사/축제"),
+    DANCE("무용/발레"),
+    FAMILY("아동/가족"),
+    ETC("기타");
+
+    private final String displayName;
+}

--- a/src/main/java/com/likelion/artipick/culture/domain/Culture.java
+++ b/src/main/java/com/likelion/artipick/culture/domain/Culture.java
@@ -1,0 +1,128 @@
+package com.likelion.artipick.culture.domain;
+
+import com.likelion.artipick.global.entity.BaseAuditEntity;
+import com.likelion.artipick.user.domain.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "culture")
+public class Culture extends BaseAuditEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "seq", unique = true)
+    private String seq;
+
+    @Column(name = "title", nullable = false, length = 200)
+    private String title;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    @Column(name = "place", nullable = false, length = 100)
+    private String place;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false)
+    private Category category;
+
+    @Column(name = "area", nullable = false, length = 50)
+    private String area;
+
+    @Column(name = "sigungu", length = 50)
+    private String sigungu;
+
+    @Column(name = "price", length = 100)
+    private String price;
+
+    @Column(name = "place_addr", length = 255)
+    private String placeAddr;
+
+    @Column(name = "gps_x", length = 255)
+    private String gpsX;
+
+    @Column(name = "gps_y", length = 255)
+    private String gpsY;
+
+    @Column(name = "place_url", length = 500)
+    private String placeUrl;
+
+    @Column(name = "phone", length = 50)
+    private String phone;
+
+    @Lob
+    @Column(name = "contents")
+    private String contents;
+
+    @Column(name = "img_url", length = 500)
+    private String imgUrl;
+
+    @Column(name = "is_from_api", nullable = false)
+    private Boolean isFromApi = true;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Builder
+    public Culture(String seq, String title, LocalDate startDate, LocalDate endDate,
+                   String place, Category category, String area, String sigungu,
+                   String price, String placeAddr, String gpsX, String gpsY,
+                   String placeUrl, String phone, String contents, String imgUrl,
+                   Boolean isFromApi, User user) {
+        this.seq = seq;
+        this.title = title;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.place = place;
+        this.category = category;
+        this.area = area;
+        this.sigungu = sigungu;
+        this.price = price;
+        this.placeAddr = placeAddr;
+        this.gpsX = gpsX;
+        this.gpsY = gpsY;
+        this.placeUrl = placeUrl;
+        this.phone = phone;
+        this.contents = contents;
+        this.imgUrl = imgUrl;
+        this.isFromApi = isFromApi != null ? isFromApi : true;
+        this.user = user;
+    }
+
+    public void updateCulture(String title, LocalDate startDate, LocalDate endDate,
+                              String place, Category category, String area, String sigungu,
+                              String price, String placeAddr, String gpsX, String gpsY,
+                              String placeUrl, String phone, String contents, String imgUrl)
+    {
+        this.title = title;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.place = place;
+        this.category = category;
+        this.area = area;
+        this.sigungu = sigungu;
+        this.price = price;
+        this.placeAddr = placeAddr;
+        this.gpsX = gpsX;
+        this.gpsY = gpsY;
+        this.placeUrl = placeUrl;
+        this.phone = phone;
+        this.contents = contents;
+        this.imgUrl = imgUrl;
+    }
+}

--- a/src/main/java/com/likelion/artipick/culture/domain/repository/CultureRepository.java
+++ b/src/main/java/com/likelion/artipick/culture/domain/repository/CultureRepository.java
@@ -1,0 +1,20 @@
+package com.likelion.artipick.culture.domain.repository;
+
+import com.likelion.artipick.culture.domain.Culture;
+import com.likelion.artipick.user.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CultureRepository extends JpaRepository<Culture, Long> {
+
+    Optional<Culture> findBySeq(String seq);
+
+    boolean existsBySeq(String seq);
+
+    Page<Culture> findByUser(User user, Pageable pageable);
+
+    Page<Culture> findByIsFromApi(Boolean isFromApi, Pageable pageable);
+}

--- a/src/main/java/com/likelion/artipick/global/code/status/ErrorStatus.java
+++ b/src/main/java/com/likelion/artipick/global/code/status/ErrorStatus.java
@@ -18,6 +18,7 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_LATITUDE(HttpStatus.BAD_REQUEST, "WEATHER4005", "유효하지 않은 위도값입니다."),
     INVALID_LONGITUDE(HttpStatus.BAD_REQUEST, "WEATHER4006", "유효하지 않은 경도값입니다."),
     INVALID_DATE_FORMAT(HttpStatus.BAD_REQUEST, "WEATHER4007", "날짜 형식이 올바르지 않습니다."),
+    CULTURE_API_EMPTY_RESPONSE(HttpStatus.BAD_GATEWAY, "CULTURE4008", "문화행사 API에서 빈 응답을 받았습니다."),
 
     // 401 Unauthorized
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "AUTH401", "인증이 필요합니다."),
@@ -57,6 +58,7 @@ public enum ErrorStatus implements BaseErrorCode {
     AI_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "CHAT5006", "AI 서버 통신 오류가 발생했습니다."),
     CHAT_SAVE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "CHAT5007", "채팅 메시지 저장 중 오류가 발생했습니다."),
     KAKAO_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "KAKAO5008", "카카오 API 통신 오류가 발생했습니다."),
+    CULTURE_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "CULTURE5009", "문화 정보 API 통신 오류가 발생했습니다."),
 
     // 502, 503, 504
     BAD_GATEWAY(HttpStatus.BAD_GATEWAY, "COMMON502", "불완전한 게이트웨이 응답을 받았습니다."),

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,6 +20,12 @@ spring:
     username: ${DB_USERNAME:root}
     password: ${DB_PASSWORD:1234}
 
+    hikari:
+      maximum-pool-size: 30        # 연결 풀 크기 증가
+      minimum-idle: 10             # 최소 idle 연결 수
+      connection-timeout: 20000    # 연결 타임아웃 20초
+      leak-detection-threshold: 60000  # 연결 누수 감지
+
   jpa:
     hibernate:
       ddl-auto: update
@@ -68,4 +74,10 @@ kakao:
 # AI 서버 설정
 ai:
   server:
-    url: ${AI_SERVER_URL} # 수정 필요
+    url: ${AI_SERVER_URL:http://localhost:9999} # 수정 필요
+
+# 문화 예술 정보 API
+culture:
+  api:
+    base-url: https://apis.data.go.kr/B553457/cultureinfo
+    auth-key: ${CULTURE_API_KEY}


### PR DESCRIPTION
# 구현 내용

- https://www.data.go.kr/iim/api/selectAPIAcountView.do 사이트에서 OpenAPI를 사용해 공공 정보를 가져온다.
- WebClient를 통해 비동기 처리
- 스케줄러를 통해 2주마다 새로운 API 정보를 가져옴