### PR TITLE
feat/#40: 검색 api 구현

### DIFF
--- a/src/main/java/com/likelion/artipick/culture/domain/repository/CultureRepository.java
+++ b/src/main/java/com/likelion/artipick/culture/domain/repository/CultureRepository.java
@@ -1,10 +1,13 @@
 package com.likelion.artipick.culture.domain.repository;
 
+import com.likelion.artipick.culture.domain.Category;
 import com.likelion.artipick.culture.domain.Culture;
 import com.likelion.artipick.user.domain.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -17,4 +20,13 @@ public interface CultureRepository extends JpaRepository<Culture, Long> {
     Page<Culture> findByUser(User user, Pageable pageable);
 
     Page<Culture> findByIsFromApi(Boolean isFromApi, Pageable pageable);
+
+    @Query("SELECT c FROM Culture c WHERE " +
+           "(:keyword IS NULL OR c.title LIKE %:keyword% OR c.contents LIKE %:keyword%) AND " +
+           "(:location IS NULL OR c.area LIKE %:location% OR c.sigungu LIKE %:location%) AND " +
+           "(:categoryEnum IS NULL OR c.category = :categoryEnum)")
+    Page<Culture> searchBy(@Param("keyword") String keyword,
+                           @Param("location") String location,
+                           @Param("categoryEnum") Category categoryEnum,
+                           Pageable pageable);
 }

--- a/src/main/java/com/likelion/artipick/global/security/SecurityConfig.java
+++ b/src/main/java/com/likelion/artipick/global/security/SecurityConfig.java
@@ -40,7 +40,8 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**",
                                 "/swagger-resources/**", "/webjars/**",
-                                "/auth/login", "/auth/reissue", "/api/weather/**", "/api/location/**"
+                                "/auth/login", "/auth/reissue", "/api/weather/**", "/api/location/**",
+                                "/api/search/**"
                         ).permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/cultures/**").permitAll()
                         .requestMatchers("/api/**").authenticated()

--- a/src/main/java/com/likelion/artipick/search/api/SearchController.java
+++ b/src/main/java/com/likelion/artipick/search/api/SearchController.java
@@ -30,7 +30,7 @@ public class SearchController {
             @RequestParam(required = false) String keyword,
             @RequestParam(required = false) String location,
             @RequestParam(required = false) String category,
-            @Parameter(description = "페이지 정보") @PageableDefault(size = 10) Pageable pageable) {
+            @Parameter(description = "페이지 정보") @PageableDefault(size = 4) Pageable pageable) {
 
         Page<CultureListResponse> cultures = searchService.searchCultures(keyword, location, category, pageable)
                 .map(CultureListResponse::from);

--- a/src/main/java/com/likelion/artipick/search/api/SearchController.java
+++ b/src/main/java/com/likelion/artipick/search/api/SearchController.java
@@ -1,0 +1,40 @@
+package com.likelion.artipick.search.api;
+
+import com.likelion.artipick.culture.api.dto.response.CultureListResponse;
+import com.likelion.artipick.global.code.dto.ApiResponse;
+import com.likelion.artipick.search.application.SearchService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "검색", description = "문화행사 검색 API")
+@RestController
+@RequestMapping("/api/search")
+@RequiredArgsConstructor
+public class SearchController {
+
+    private final SearchService searchService;
+
+    @Operation(summary = "문화행사 검색", description = "키워드, 지역, 카테고리로 문화행사를 검색합니다.")
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<CultureListResponse>>> searchCulture(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) String location,
+            @RequestParam(required = false) String category,
+            @Parameter(description = "페이지 정보") @PageableDefault(size = 10) Pageable pageable) {
+
+        Page<CultureListResponse> cultures = searchService.searchCultures(keyword, location, category, pageable)
+                .map(CultureListResponse::from);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(cultures));
+    }
+}

--- a/src/main/java/com/likelion/artipick/search/application/SearchService.java
+++ b/src/main/java/com/likelion/artipick/search/application/SearchService.java
@@ -1,0 +1,32 @@
+package com.likelion.artipick.search.application;
+
+import com.likelion.artipick.culture.domain.Category;
+import com.likelion.artipick.culture.domain.Culture;
+import com.likelion.artipick.culture.domain.repository.CultureRepository;
+import com.likelion.artipick.global.code.status.ErrorStatus;
+import com.likelion.artipick.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SearchService {
+
+    private final CultureRepository cultureRepository;
+
+    public Page<Culture> searchCultures(String keyword, String location, String category, Pageable pageable) {
+        Category categoryEnum = null;
+        if (category != null && !category.isEmpty()) {
+            try {
+                categoryEnum = Category.fromDisplayName(category);
+            } catch (IllegalArgumentException e) {
+                throw new GeneralException(ErrorStatus.CATEGORY_NOT_FOUND);
+            }
+        }
+        return cultureRepository.searchBy(keyword, location, categoryEnum, pageable);
+    }
+}


### PR DESCRIPTION
## 구현 기능

## 1. `SearchController.java` 구현

*   `@RequestMapping("/api/search")`를 통해 요청하신 엔드포인트에 매핑
*   `keyword`, `location`, `category`, `page`, `size` 파라미터를 받아 `SearchService`로 전달
*   검색 결과를 `CultureListResponse` 형태로 반환

## 2. `SearchService.java` 구현

*   `CultureRepository`를 주입받아 데이터베이스 검색
*   `category` 문자열을 `Category` enum 타입으로 변환하는 로직을 포함합니다. (이 과정에서 `Category.java`의 `fromDisplayName` 메서드를 사용합니다.)
*   유효하지 않은 카테고리 이름이 들어올 경우 "카테고리를 찾을 수 없습니다." 에러를 반환

## 3. `CultureRepository.java` 수정
**주요 변경 사항**:
*   `@Query` 어노테이션을 사용하여 `keyword`, `location`, `category`를 기반으로 문화 행사를 검색하는 `searchBy` 메서드를 추가