### PR TITLE
fix/#42: 카테고리 중복 검색 허용 및 location이 아닌 area와 sigungu 모두 입력받도록 수정

### DIFF
--- a/src/main/java/com/likelion/artipick/culture/domain/repository/CultureRepository.java
+++ b/src/main/java/com/likelion/artipick/culture/domain/repository/CultureRepository.java
@@ -23,10 +23,12 @@ public interface CultureRepository extends JpaRepository<Culture, Long> {
 
     @Query("SELECT c FROM Culture c WHERE " +
            "(:keyword IS NULL OR c.title LIKE %:keyword% OR c.contents LIKE %:keyword%) AND " +
-           "(:location IS NULL OR c.area LIKE %:location% OR c.sigungu LIKE %:location%) AND " +
-           "(:categoryEnum IS NULL OR c.category = :categoryEnum)")
+           "(:area IS NULL OR c.area LIKE %:area%) AND " +
+           "(:sigungu IS NULL OR c.sigungu LIKE %:sigungu%) AND " +
+           "(:categories IS NULL OR c.category IN :categories)")
     Page<Culture> searchBy(@Param("keyword") String keyword,
-                           @Param("location") String location,
-                           @Param("categoryEnum") Category categoryEnum,
+                           @Param("area") String area,
+                           @Param("sigungu") String sigungu,
+                           @Param("categories") java.util.List<Category> categories,
                            Pageable pageable);
 }

--- a/src/main/java/com/likelion/artipick/search/api/SearchController.java
+++ b/src/main/java/com/likelion/artipick/search/api/SearchController.java
@@ -28,11 +28,12 @@ public class SearchController {
     @GetMapping
     public ResponseEntity<ApiResponse<Page<CultureListResponse>>> searchCulture(
             @RequestParam(required = false) String keyword,
-            @RequestParam(required = false) String location,
+            @RequestParam(required = false) String area,
+            @RequestParam(required = false) String sigungu,
             @RequestParam(required = false) String category,
             @Parameter(description = "페이지 정보") @PageableDefault(size = 4) Pageable pageable) {
 
-        Page<CultureListResponse> cultures = searchService.searchCultures(keyword, location, category, pageable)
+        Page<CultureListResponse> cultures = searchService.searchCultures(keyword, area, sigungu, category, pageable)
                 .map(CultureListResponse::from);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(cultures));

--- a/src/main/java/com/likelion/artipick/search/application/SearchService.java
+++ b/src/main/java/com/likelion/artipick/search/application/SearchService.java
@@ -18,15 +18,18 @@ public class SearchService {
 
     private final CultureRepository cultureRepository;
 
-    public Page<Culture> searchCultures(String keyword, String location, String category, Pageable pageable) {
-        Category categoryEnum = null;
-        if (category != null && !category.isEmpty()) {
+    public Page<Culture> searchCultures(String keyword, String area, String sigungu, String category, Pageable pageable) {
+        java.util.List<Category> categoryEnums = null;
+        if (category != null && !category.isBlank()) {
             try {
-                categoryEnum = Category.fromDisplayName(category);
+                categoryEnums = java.util.Arrays.stream(category.split(","))
+                        .map(String::trim)
+                        .map(Category::fromDisplayName)
+                        .collect(java.util.stream.Collectors.toList());
             } catch (IllegalArgumentException e) {
                 throw new GeneralException(ErrorStatus.CATEGORY_NOT_FOUND);
             }
         }
-        return cultureRepository.searchBy(keyword, location, categoryEnum, pageable);
+        return cultureRepository.searchBy(keyword, area, sigungu, categoryEnums, pageable);
     }
 }


### PR DESCRIPTION
## 구현 기능
* 원래 카테고리 중복 검색이 안 되는 걸 중복 검색이 되도록 변경
  * endPoint: /api/search?category=연극,전시
  
* 원래는 location에 area 또는 sigungu만 넣으면 됐지만, area와 sigungu 모두 입력 받도록 수정
  * endPoint: /api/search?area=서울
  * endPoint: /api/search?sigungu=종로구
  * endPoint: /api/search?area=서울?sigungu=종로구