### PR TITLE
feat/#46: 배포된 프론트 주소 CORS 설정

### DIFF
--- a/src/main/java/com/likelion/artipick/global/security/SecurityConfig.java
+++ b/src/main/java/com/likelion/artipick/global/security/SecurityConfig.java
@@ -56,7 +56,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000", "http://localhost:5173",
-                "https://artipick.duckdns.org"));
+                "https://artipick.duckdns.org", "https://artipick.vercel.app"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("Authorization", "RefreshToken", "id_token", "Content-Type"));
         configuration.setExposedHeaders(Arrays.asList("Authorization", "RefreshToken"));


### PR DESCRIPTION
# 구현 기능
- SecurityCofing에 배포된 프론트 주소 추가