### PR TITLE
fix/#55: 비인가 사용자도 추천 api 사용할 수 있도록 수정

### DIFF
--- a/src/main/java/com/likelion/artipick/global/security/SecurityConfig.java
+++ b/src/main/java/com/likelion/artipick/global/security/SecurityConfig.java
@@ -41,7 +41,7 @@ public class SecurityConfig {
                                 "/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**",
                                 "/swagger-resources/**", "/webjars/**",
                                 "/auth/login", "/auth/reissue", "/api/weather/**", "/api/location/**",
-                                "/api/search/**"
+                                "/api/search/**", "/api/recommendations/**"
                         ).permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/cultures/**").permitAll()
                         .requestMatchers("/api/**").authenticated()


### PR DESCRIPTION
# 수정 내용
- SecurityCofing 추천 엔드포인트 추가