### PR TITLE
feat/#57: 마이페이지에서 찜한 게시글 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/likelion/artipick/culture/domain/repository/CultureLikeRepository.java
+++ b/src/main/java/com/likelion/artipick/culture/domain/repository/CultureLikeRepository.java
@@ -3,10 +3,14 @@ package com.likelion.artipick.culture.domain.repository;
 import com.likelion.artipick.culture.domain.Culture;
 import com.likelion.artipick.culture.domain.CultureLike;
 import com.likelion.artipick.user.domain.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface CultureLikeRepository extends JpaRepository<CultureLike, Long> {
     Optional<CultureLike> findByUserAndCulture(User user, Culture culture);
+
+    Page<CultureLike> findAllByUserIdAndLikedTrue(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/likelion/artipick/mypage/api/MyPageController.java
+++ b/src/main/java/com/likelion/artipick/mypage/api/MyPageController.java
@@ -2,6 +2,7 @@ package com.likelion.artipick.mypage.api;
 
 import com.likelion.artipick.global.code.dto.ApiResponse;
 import com.likelion.artipick.global.security.CustomUserDetails;
+import com.likelion.artipick.mypage.api.dto.response.MyPageCultureResponseDto;
 import com.likelion.artipick.mypage.api.dto.response.MyPagePlaceResponseDto;
 import com.likelion.artipick.mypage.api.dto.response.MyPageUserResponseDto;
 import com.likelion.artipick.mypage.api.dto.request.ProfileUpdateRequestDto;
@@ -47,5 +48,14 @@ public class MyPageController {
             Pageable pageable) {
         Page<MyPagePlaceResponseDto> bookmarkedPlaces = myPageService.getBookmarkedPlaces(userDetails.getUserId(), pageable);
         return ResponseEntity.ok(ApiResponse.onSuccess(bookmarkedPlaces));
+    }
+
+    @Operation(summary = "내가 찜한 문화생활 목록 조회")
+    @GetMapping("/likes")
+    public ResponseEntity<ApiResponse<Page<MyPageCultureResponseDto>>> getMyLikedCultures(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            Pageable pageable) {
+        Page<MyPageCultureResponseDto> likedCultures = myPageService.getLikedCultures(userDetails.getUserId(), pageable);
+        return ResponseEntity.ok(ApiResponse.onSuccess(likedCultures));
     }
 }

--- a/src/main/java/com/likelion/artipick/mypage/api/dto/response/MyPageCultureResponseDto.java
+++ b/src/main/java/com/likelion/artipick/mypage/api/dto/response/MyPageCultureResponseDto.java
@@ -1,0 +1,28 @@
+package com.likelion.artipick.mypage.api.dto.response;
+
+import com.likelion.artipick.culture.domain.Culture;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "내가 찜한 문화생활 목록 조회 응답 DTO")
+public record MyPageCultureResponseDto(
+    @Schema(description = "문화 ID", example = "1")
+    Long cultureId,
+    @Schema(description = "제목", example = "패트릭 블랑: 수직정원")
+    String title,
+    @Schema(description = "포스터 이미지 URL", example = "http://www.culture.go.kr/upload/rdf/1.jpg")
+    String imgUrl,
+    @Schema(description = "장소", example = "부산현대미술관")
+    String place,
+    @Schema(description = "카테고리", example = "전시")
+    String category
+) {
+    public static MyPageCultureResponseDto from(Culture culture) {
+        return new MyPageCultureResponseDto(
+            culture.getId(),
+            culture.getTitle(),
+            culture.getImgUrl(),
+            culture.getPlace(),
+            culture.getCategory().getDisplayName()
+        );
+    }
+}

--- a/src/main/java/com/likelion/artipick/mypage/application/MyPageService.java
+++ b/src/main/java/com/likelion/artipick/mypage/application/MyPageService.java
@@ -1,8 +1,10 @@
 package com.likelion.artipick.mypage.application;
 
+import com.likelion.artipick.culture.domain.repository.CultureLikeRepository;
 import com.likelion.artipick.global.code.status.ErrorStatus;
 import com.likelion.artipick.global.exception.GeneralException;
 
+import com.likelion.artipick.mypage.api.dto.response.MyPageCultureResponseDto;
 import com.likelion.artipick.mypage.api.dto.response.MyPagePlaceResponseDto;
 import com.likelion.artipick.mypage.api.dto.response.MyPageUserResponseDto;
 import com.likelion.artipick.mypage.api.dto.request.ProfileUpdateRequestDto;
@@ -27,6 +29,7 @@ public class MyPageService {
     private final UserRepository userRepository;
     private final PlaceBookmarkRepository placeBookmarkRepository;
     private final InterestCategoryRepository interestCategoryRepository;
+    private final CultureLikeRepository cultureLikeRepository;
 
     public MyPageUserResponseDto getMyPageInfo(Long userId) {
         User user = userRepository.findById(userId)
@@ -50,5 +53,10 @@ public class MyPageService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
         user.updateProfile(profileUpdateRequestDto.nickname(), profileUpdateRequestDto.introduction());
+    }
+
+    public Page<MyPageCultureResponseDto> getLikedCultures(Long userId, Pageable pageable) {
+        return cultureLikeRepository.findAllByUserIdAndLikedTrue(userId, pageable)
+                .map(cultureLike -> MyPageCultureResponseDto.from(cultureLike.getCulture()));
     }
 }


### PR DESCRIPTION
## 구현 기능
* 마이페이지에서 찜한 게시글 목록 조회 구현
  * endPoint: /api/me/likes